### PR TITLE
terminate statement with semicolon

### DIFF
--- a/src/soap_req.erl
+++ b/src/soap_req.erl
@@ -304,7 +304,7 @@ soap_env(Body, Headers, _) ->
      <<"</S:Body></S:Envelope>">>].
 
 headers([]) ->
-    [<<"<env:Header/>">>].
+    [<<"<env:Header/>">>];
 headers(Headers) ->
     [<<"<env:Header>">>, Headers, <<"</env:Header>">>].
 


### PR DESCRIPTION
love 2 terminate multiple function code bodies with semicolons instead
of periods. love the erlang syntax
